### PR TITLE
Add yarn-install-dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@ Install selected packages from `devDependencies`.
 This is to provide solution for [yarnpkg/yarn#5201].
 
 [yarnpkg/yarn#5201]: https://github.com/yarnpkg/yarn/issues/5201
+
+## Installation
+
+Recommended installation is to install as global.
+
+```shell
+npm install -g yarn-install-dev
+```
+
+## Usage
+
+Install `typescript` version specified in `devDependencies`:
+
+```shell
+yarn-install-dev typescript
+```
+
+This will run `yarn install --frozen-lockfile --production` with modified `package.json`.
+The `package.json` file is restored to original state after `yarn` execution.

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,0 +1,44 @@
+import { spawn } from "node:child_process";
+import { EOL } from "node:os";
+
+import type { Readable } from "node:stream";
+
+/**
+ * Consume stream, split by newlines.
+ *
+ * @author Elan Ruusamäe <glen@pld-linux.org>
+ */
+const getStreamData = async (stream: Readable): Promise<string[]> => {
+  const lines = [];
+
+  for await (const data of stream) {
+    lines.push(data);
+  }
+
+  return lines
+    .join("")
+    .trim()
+    .split(EOL);
+};
+
+/**
+ * Execute a command, return stdout on success,
+ * throw Error on error with output from stderr.
+ *
+ * @author Elan Ruusamäe <glen@pld-linux.org>
+ */
+export const exec = async (command: string): Promise<string[]> => {
+  const [cmd, ...args] = command.split(" ");
+  const cp = spawn(cmd, args);
+
+  const [out, err] = await Promise.all([
+    getStreamData(cp.stdout),
+    getStreamData(cp.stderr),
+  ]);
+
+  if (cp.exitCode) {
+    throw new Error(err.length ? err.join("\n") : `Process exited with code ${cp.exitCode}`);
+  }
+
+  return out;
+};

--- a/src/yarn-install-dev.ts
+++ b/src/yarn-install-dev.ts
@@ -1,5 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import { copyFile } from "node:fs/promises";
+import { EOL } from "node:os";
 
 import findUp from "find-up";
 
@@ -29,7 +30,11 @@ const addDeps = async (packagePath: string, dependencies: string[]): Promise<voi
 
   await writeFile(packagePath, JSON.stringify(pkg));
   console.debug(`Wrote ${packagePath}`, pkg);
-  await exec("yarn install --frozen-lockfile --production");
+
+  const yarnInstall = "yarn install --frozen-lockfile --production";
+
+  console.info(`Running ${yarnInstall}`);
+  process.stdout.write((await exec(yarnInstall)).join(EOL));
 };
 
 const main = async (dependencies: string[]): Promise<void> => {

--- a/src/yarn-install-dev.ts
+++ b/src/yarn-install-dev.ts
@@ -17,14 +17,22 @@ const addDeps = async (packagePath: string, dependencies: string[]): Promise<voi
 
   // Copy from devDependencies
   for (const dep of dependencies) {
+    console.info(`Copying from devDependencies: ${dep}`);
     pkg.dependencies[dep] = pkg.devDependencies[dep];
   }
 
   await writeFile(packagePath, JSON.stringify(pkg));
+  console.debug(`Wrote ${packagePath}`, pkg);
   await exec("yarn install --frozen-lockfile --production");
 };
 
 const main = async (dependencies: string[]): Promise<void> => {
+  if (!dependencies.length) {
+    console.warn("No dependencies to install; Skipping.");
+
+    return;
+  }
+
   const packagePath = await findUp("package.json");
 
   if (!packagePath) {
@@ -33,12 +41,14 @@ const main = async (dependencies: string[]): Promise<void> => {
 
   const backupPath = `${packagePath}.bak`;
 
+  console.info(`Creating backup: ${packagePath} -> ${backupPath}`);
   await copyFile(packagePath, backupPath);
 
   try {
     await addDeps(packagePath, dependencies);
   } finally {
     await copyFile(backupPath, packagePath);
+    console.info(`Restored backup: ${backupPath} -> ${packagePath}`);
   }
 };
 

--- a/src/yarn-install-dev.ts
+++ b/src/yarn-install-dev.ts
@@ -1,0 +1,46 @@
+import { writeFile } from "node:fs/promises";
+import { copyFile } from "node:fs/promises";
+
+import findUp from "find-up";
+
+import { exec } from "./exec";
+
+/**
+ * @see https://github.com/yarnpkg/yarn/issues/5201#issuecomment-1059988319 (v1)
+ * @see https://github.com/yarnpkg/yarn/issues/5201#issuecomment-1098199645 (v2)
+ */
+const addDeps = async (packagePath: string, dependencies: string[]): Promise<void> => {
+  const pkg = require(packagePath);
+
+  // Ensure section exists
+  pkg.dependencies = pkg.dependencies || {};
+
+  // Copy from devDependencies
+  for (const dep of dependencies) {
+    pkg.dependencies[dep] = pkg.devDependencies[dep];
+  }
+
+  await writeFile(packagePath, JSON.stringify(pkg));
+  await exec("yarn install --frozen-lockfile --production");
+};
+
+const main = async (dependencies: string[]): Promise<void> => {
+  const packagePath = await findUp("package.json");
+
+  if (!packagePath) {
+    throw new Error("Could not find package.json");
+  }
+
+  const backupPath = `${packagePath}.bak`;
+
+  await copyFile(packagePath, backupPath);
+
+  try {
+    await addDeps(packagePath, dependencies);
+  } finally {
+    await copyFile(backupPath, packagePath);
+  }
+};
+
+main(process.argv.slice(2))
+  .catch(e => console.error(e));

--- a/src/yarn-install-dev.ts
+++ b/src/yarn-install-dev.ts
@@ -17,6 +17,12 @@ const addDeps = async (packagePath: string, dependencies: string[]): Promise<voi
 
   // Copy from devDependencies
   for (const dep of dependencies) {
+    if (!pkg.devDependencies[dep]) {
+      console.warn(`Skipping in-existent dependency: ${dep}`);
+
+      continue;
+    }
+
     console.info(`Copying from devDependencies: ${dep}`);
     pkg.dependencies[dep] = pkg.devDependencies[dep];
   }


### PR DESCRIPTION
## Usage

Install `typescript` version specified in `devDependencies`:

```shell
yarn-install-dev typescript
```

This will run `yarn install --frozen-lockfile --production` with modified `package.json`.
The `package.json` file is restored to original state after `yarn` execution.

Refs:
- https://github.com/yarnpkg/yarn/issues/5201